### PR TITLE
Fix gpio readall table

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following properties can be configured:
 <br>
 <p>
 If you want to find the right pin:
+	
 ```
 pi@raspberrypi:~ $ gpio readall
  +-----+-----+---------+------+---+---Pi 2---+---+------+---------+-----+-----+


### PR DESCRIPTION
The markdown was broken so the tables was unreadable.