### PR TITLE
Fix `gpio readall` displaying in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following properties can be configured:
 <br>
 <p>
 If you want to find the right pin:
+
 ```
 pi@raspberrypi:~ $ gpio readall
  +-----+-----+---------+------+---+---Pi 2---+---+------+---------+-----+-----+


### PR DESCRIPTION
I just added a new line in order to improve how `gpio readall` is displayed in the GitHub (right now there is no formatting). 