### PR TITLE
Fix link to WiringPi in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Additional Module for MagicMirror²  https://github.com/MichMich/MagicMirror
 
 ## Dependencies
 - An installation of [MagicMirror<sup>2</sup>](https://github.com/MichMich/MagicMirror)
-- [WiringPi] (http://wiringpi.com/download-and-install/)
+- [WiringPi](http://wiringpi.com/download-and-install/)
 
 ## Installation
 


### PR DESCRIPTION
I just removed space to fix the link. 